### PR TITLE
Enhanced nodeinfo tool to write network map based on additional node …

### DIFF
--- a/experimental/nodeinfo/build.gradle
+++ b/experimental/nodeinfo/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     compile "org.slf4j:jul-to-slf4j:$slf4j_version"
     compile "org.apache.logging.log4j:log4j-slf4j-impl:$log4j_version"
     compile "com.jcabi:jcabi-manifests:$jcabi_manifests_version"
+    compile "com.google.code.gson:gson:2.8.5"
     compile project(':core')
     compile project(':node-api')
 }

--- a/experimental/nodeinfo/src/main/kotlin/net.corda.nodeinfo/NodeInfo.kt
+++ b/experimental/nodeinfo/src/main/kotlin/net.corda.nodeinfo/NodeInfo.kt
@@ -4,6 +4,7 @@ import net.corda.cliutils.CordaCliWrapper
 import net.corda.cliutils.start
 import net.corda.core.crypto.sign
 import net.corda.core.identity.PartyAndCertificate
+import net.corda.core.identity.CordaX500Name
 import net.corda.core.internal.div
 import net.corda.core.internal.readAll
 import net.corda.core.node.NodeInfo
@@ -24,9 +25,12 @@ import net.corda.serialization.internal.amqp.amqpMagic
 import picocli.CommandLine.ITypeConverter
 import picocli.CommandLine.Option
 import java.io.File
+import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.HashMap
 import java.security.cert.CertificateFactory
-
+import com.google.gson.GsonBuilder
 /**
  * NodeInfo signing tool for Corda
  *
@@ -64,6 +68,12 @@ class NodeInfoSigner : CordaCliWrapper("nodeinfo-signer", "Display and generate 
 
     @Option(names = ["--display"], paramLabel = "nodeinfo-file", description = ["Path to NodeInfo"])
     private var displayPath: Path? = null
+
+    @Option(names = ["--network-map"], paramLabel = "directory", description = ["additional-node-infos directory"])
+    private var additionalNodeInfosPath: Path? = null
+
+    @Option(names = ["--outfile"], paramLabel = "file", description = ["Output file for JSON format network map"])
+    private var outputFile: Path? = null
 
     @Option(names = ["--address"], paramLabel = "host:port", description = ["Public address of node"], converter = [NetworkHostAndPortConverter::class])
     private var addressList: MutableList<NetworkHostAndPort> = mutableListOf<NetworkHostAndPort>()
@@ -136,6 +146,8 @@ class NodeInfoSigner : CordaCliWrapper("nodeinfo-signer", "Display and generate 
         return NodeInfoAndSignedNodeInfo(nodeInfo, sni)
     }
 
+    class SimplifiedNodeInfo(val identity : CordaX500Name, val address : NetworkHostAndPort)
+
     override fun runProgram(): Int {
 
         initialiseSerialization()
@@ -147,6 +159,25 @@ class NodeInfoSigner : CordaCliWrapper("nodeinfo-signer", "Display and generate 
             println("address:         " + nodeInfo.addresses[0])
             println("platformVersion: " + nodeInfo.platformVersion)
             println("serial           " + nodeInfo.serial)
+            return 0;
+        } else if(additionalNodeInfosPath != null) {
+            val nodeinfos = mutableListOf<SimplifiedNodeInfo>()
+            Files.walk(additionalNodeInfosPath)
+                .filter{item -> Files.isRegularFile(item)}
+                .forEach{
+                    val nodeinfo = nodeInfoFromFile(it.toFile())
+                    nodeinfos.add(SimplifiedNodeInfo(nodeinfo.legalIdentities[0].name, nodeinfo.addresses[0]))
+                };
+
+            val gson = GsonBuilder().setPrettyPrinting().create()
+            val prettyPrint = gson.toJson(nodeinfos)
+            println(prettyPrint)
+
+            if (outputFile != null) {
+                val file = outputFile!!.toString()
+                File(file).writeText(prettyPrint)
+            }
+
             return 0;
         }
         else {


### PR DESCRIPTION
…infos dir content

Added two additional parameters:
```
--network-map=<directory> specify the additional-node-infos folder
--outfile=<file> specify the location of the network-map.json file
```

This can be utilized by programs other than Java to be able to understand the network topology