### PR TITLE
Revert "Update h2 to 1.4.200 for the support of autoCompactFillRate"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ buildscript {
     ext.jopt_simple_version = '5.0.2'
     ext.jansi_version = '1.18'
     ext.hibernate_version = '5.4.3.Final'
-    ext.h2_version = '1.4.200' // Update docs if renamed or removed.
+    ext.h2_version = '1.4.199' // Update docs if renamed or removed.
     ext.rxjava_version = '1.3.8'
     ext.dokka_version = '0.9.17'
     ext.eddsa_version = '0.3.0'


### PR DESCRIPTION
Seeing these errors after the upgrade, reverted for now:

```
[ERROR] 06:56:05+0000 [main] changelog.ChangeSet. - Change Set migration/vault-schema.changelog-v9.xml::update-vault-states::R3.Corda failed. Error: org.hibernate.exception.GenericJDBCException: could not extract ResultSet {changeSet=migration/vault-schema.changelog-v9.xml::update-vault-states::R3.Corda, databaseChangeLog=master.changelog.json}
[INFO] 06:56:05+0000 [main] lockservice.StandardLockService. - Successfully released change log lock
[ERROR] 06:56:05+0000 [main] internal.NodeStartupLogging. - Could not create the DataSource: Migration failed for change set migration/vault-schema.changelog-v9.xml::update-vault-states::R3.Corda:
   Reason: javax.persistence.PersistenceException: org.hibernate.exception.GenericJDBCException: could not extract ResultSet: Could not create the DataSource: Migration failed for change set migration/vault-schema.changelog-v9.xml::update-vault-states::R3.Corda:
   Reason: javax.persistence.PersistenceException: org.hibernate.exception.GenericJDBCException: could not extract ResultSet [errorCode=9766y2, moreInformationAt=https://errors.corda.net/OS/4.4-SNAPSHOT/9766y2] (edited) 
```