### PR TITLE
Updated netty version to 4.1.49 for CVE-2020-11612 fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ buildscript {
     ext.djvm_version = constants.getProperty("djvmVersion")
     ext.deterministic_rt_version = constants.getProperty('deterministicRtVersion')
     ext.okhttp_version = '3.14.2'
-    ext.netty_version = '4.1.29.Final'
+    ext.netty_version = '4.1.49.Final'
     ext.tcnative_version = '2.0.14.Final'
     ext.typesafe_config_version = constants.getProperty("typesafeConfigVersion")
     ext.fileupload_version = '1.4'


### PR DESCRIPTION
Ran through an end to end flow in dev using a branch build. submitting 10 transactions in a row using the `kaleido-corda-samples/rpc-client`. all completed successfully